### PR TITLE
Fix app crashes - fail safely

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -122,5 +122,7 @@
     <string name="ps_ip_address">IP Address (LHOST)</string>
     <string name="ps_port">Port (LPORT)</string>
     <string name="ps_payload_url">URL to payload</string>
+
+    <string name="toast_install_terminal">Error launching intent. Install Android Terminal!</string>
     
 </resources>

--- a/src/com/offsec/nethunter/KaliLauncherFragment.java
+++ b/src/com/offsec/nethunter/KaliLauncherFragment.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 public class KaliLauncherFragment extends Fragment {
     /**
@@ -39,11 +40,15 @@ public class KaliLauncherFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.kali_launcher, container, false);
         addClickListener(R.id.button_start_kali, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali");
-                startActivity(intent);
+                try {
+                    Intent intent =
+	                        new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali");
+                    startActivity(intent);
+	            } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         /**
@@ -51,11 +56,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.button_start_kalimenu, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali kalimenu");
-                startActivity(intent);
+                try {
+                    Intent intent =
+                            new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali kalimenu");
+                    startActivity(intent);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         /**
@@ -63,11 +72,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.update_kali_chroot, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali update");
-                startActivity(intent);
+                try {
+                    Intent intent =
+                            new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali update");
+                    startActivity(intent);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         /**
@@ -75,11 +88,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.button_launch_wifite, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali wifite");
-                startActivity(intent);
+                try {
+                    Intent intent =
+                            new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali wifite");
+                    startActivity(intent);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         
@@ -88,11 +105,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.turn_off_external_wifi, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali wifi-disable");
-                startActivity(intent);
+                try {
+                    Intent intent =
+                            new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali wifi-disable");
+                    startActivity(intent);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         /**
@@ -100,11 +121,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.shutdown_kali, new View.OnClickListener() {
             public void onClick(View v) {
-                Intent intent =
-                        new Intent("jackpal.androidterm.RUN_SCRIPT");
-                intent.addCategory(Intent.CATEGORY_DEFAULT);
-                intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c killkali");
-                startActivity(intent);
+                try {
+                    Intent intent =
+                            new Intent("jackpal.androidterm.RUN_SCRIPT");
+                    intent.addCategory(Intent.CATEGORY_DEFAULT);
+                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c killkali");
+                    startActivity(intent);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+                }
             }
         }, rootView);
         return rootView;

--- a/src/com/offsec/nethunter/KaliServicesFragment.java
+++ b/src/com/offsec/nethunter/KaliServicesFragment.java
@@ -186,6 +186,9 @@ class SwichLoader extends BaseAdapter {
         vH.sw.setChecked(false);
         // check it
 
+        if (position>=curstats.length) {
+            return convertView;
+        }
         if (curstats[position].equals("1")) {
             vH.sw.setChecked(true);
             vH.sw.setTextColor(mContext.getResources().getColor(R.color.blue));


### PR DESCRIPTION
This patch fixes few app crashes. It will try to fail safely if intent is not available or services are not reachable. 

For example, there is no written requirement for jackpal android terminal emulator:
http://www.nethunter.com/prepare/

but if android terminal is not installed, this application will die in terrible death (Nethunter ended unexpectedly..) when you try to launch kali in terminal (or any other which requires android terminal). This patch tries to fail safely, so app will not crash, but it will tell user that android terminal is missing. 

Another fix is array handling and if services are not available. Again, app will die by terrible death. 

