### PR TITLE
Custom Buttons for Kali Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+nethunter-app modified version with custom kali buttons.
+
+For example I really like to have nmap -Ss IP/24 as a custom button, so I decided to update nethunter!
+
+You need to add the following lines at the end of bootkali:
+
+if [ "$1" == "custom_cmd" ]; then
+
+LANG=C PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $busybox chroot $mnt $2
+
+fi

--- a/res/layout/kali_launcher.xml
+++ b/res/layout/kali_launcher.xml
@@ -4,52 +4,73 @@
     android:orientation="vertical"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <Button
-        android:id="@+id/button_start_kali"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/launch_kali_shell"
-        android:textColor="#ffffffff" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/button_start_kalimenu"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/launch_kali_menu"
-        android:textColor="#ffffffff" />
+        <LinearLayout
+            android:id="@+id/launcher_layout"
+            android:layout_width="fill_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-    <Button
-        android:id="@+id/button_launch_wifite"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/launch_wifite"
-        android:clickable="true"
-        android:textColor="#ffffffff" />
-	<Button
-        android:id="@+id/update_kali_chroot"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/update_kali_chroot"
-        android:clickable="true"
-        android:textColor="#ffffffff" />
-	<Button
-        android:id="@+id/turn_off_external_wifi"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/turn_off_external_wifi"
-        android:clickable="true"
-        android:textColor="#ffffffff" />      
-	<Button
-        android:id="@+id/shutdown_kali"
-        android:layout_weight="1"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/shutdown_kali"
-        android:clickable="true"
-        android:textColor="#ffffffff" />
+            <Button
+                android:id="@+id/add_Button"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/add_button"
+                android:clickable="true"
+                android:textColor="#ff95ff84" />
+
+            <Button
+                android:id="@+id/button_start_kali"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/launch_kali_shell"
+                android:textColor="#ffffffff" />
+
+            <Button
+                android:id="@+id/button_start_kalimenu"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/launch_kali_menu"
+                android:textColor="#ffffffff" />
+
+            <Button
+                android:id="@+id/button_launch_wifite"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/launch_wifite"
+                android:clickable="true"
+                android:textColor="#ffffffff" />
+            <Button
+                android:id="@+id/update_kali_chroot"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/update_kali_chroot"
+                android:clickable="true"
+                android:textColor="#ffffffff" />
+            <Button
+                android:id="@+id/turn_off_external_wifi"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/turn_off_external_wifi"
+                android:clickable="true"
+                android:textColor="#ffffffff" />
+            <Button
+                android:id="@+id/shutdown_kali"
+                android:layout_weight="1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/shutdown_kali"
+                android:clickable="true"
+                android:textColor="#ffffffff" />
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/res/layout/newapplauncher.xml
+++ b/res/layout/newapplauncher.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/add_lauchner_btn_label_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_lauchner_btn_label"
+        android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <EditText
+        android:id="@+id/editText_launcher_btn_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+        <requestFocus />
+    </EditText>
+
+    <TextView
+        android:id="@+id/add_lauchner_btn_command_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_lauchner_btn_command"
+        android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <EditText
+        android:id="@+id/editText_launcher_command"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_nav_home_label">NetHunter Home</string>
 
 
-	<string name="hometitle">Kali Linux NetHunter</string>
+    <string name="hometitle">Kali Linux NetHunter</string>
     <string name="nethunter_label">Nethunter Panel Home</string>
     <string name="nethunter_description">Welcome to Kali Linux NetHunter, by Offensive Security! This application is designed to make it easier to execute attacks and control services. The navigation menu contains links to useful commands, settings, macros, and attack configuration pages. Most configurations work out of the box but some may require some minimal tweaking.</string>
     <string name="nethunter_current_interfaces">Current interfaces</string>
@@ -16,7 +16,7 @@
     <string name="hid_label">HID Keyboard Attack</string>
     <string name="hid_powersploit_description">The Powersploit payload provides you a choice of reverse meterpreter HTTP/S payloads. "URL to payload" should be a URL accessible to the victim machine where the larger payload is downloaded to.</string>
     <string name="hid_windows_cmd_description">This Windows CMD payload allows you to enter raw commands to a Windows command prompt. Hitting the list menu will allow you to choose keyboard layout or UAC bypass options. </string>
-    
+
     <string name="hid_admin_select">Please select</string>
     <string-array name="hid_admin_options">
         <item>win7</item>
@@ -32,15 +32,15 @@
     <string name="mana_headline">Evil Access Point</string>
     <string name="mana_description">This is the configuration page for MANA, an evil access point implementation by Sensepost. The various MITM logs get written to the /var/lib/mana-toolkit directory in the Kali chroot..</string>
 
-	<string name="mana_hostapd">The hostapd configuration file used by Mana.</string>
-	<string name="mana_dhcpd">The dhcpd configuration file used by Mana.</string>
-	<string name="mana_dnsspoof">The dnsspoof configuration file used by Mana.</string>
-	<string name="mana_nat_full">The Mana script that does full NAT &amp; SSL interception.</string>
-	<string name="mana_nat_simple">The Mana script that does full NAT only.</string>
-	<string name="mana_nat_simple_bdf">The Mana script that does full NAT &amp; BDFProxy HTTP routing to port 8080.</string>
+    <string name="mana_hostapd">The hostapd configuration file used by Mana.</string>
+    <string name="mana_dhcpd">The dhcpd configuration file used by Mana.</string>
+    <string name="mana_dnsspoof">The dnsspoof configuration file used by Mana.</string>
+    <string name="mana_nat_full">The Mana script that does full NAT &amp; SSL interception.</string>
+    <string name="mana_nat_simple">The Mana script that does full NAT only.</string>
+    <string name="mana_nat_simple_bdf">The Mana script that does full NAT &amp; BDFProxy HTTP routing to port 8080.</string>
     <string name="bdfproxy_cfg">The configuration file for BDFProxy.</string>
-	<string name="mana_noupstream">The Mana no-upstream run script.</string>
-	<string name="mana_noupstream_eap">The Mana no-upstream EAP run script.</string>
+    <string name="mana_noupstream">The Mana no-upstream run script.</string>
+    <string name="mana_noupstream_eap">The Mana no-upstream EAP run script.</string>
 
     <string name="dnsmasq_label">Dnsmasq Service</string>
     <string name="dnsmasq_headline">Dnsmasq Config</string>
@@ -50,12 +50,12 @@
     <string name="hostapd_headline">Hostapd Config</string>
     <string name="hostapd_description">hostapd is a user space daemon for wireless access point and authentication servers. You can use hostapd to easily create a wireless access point using these configuration options:</string>
 
-	<string name="duckhunter_label">HID Ducky Script Attacks</string>
-	<string name="select_language">Language</string>
-	<string name="duckConvertUpdate">Update</string>
-	<string name="duckConvertConvert">Convert</string>
-	<string name="duckPreviewRefresh">Refresh</string>	
-	<string name="duck_hunter_headline">The DuckHunter script can easily convert "USB Rubber Ducky" scripts into NetHunter HID format.  You can generate preconfigured scripts at the incredibly useful <a href="http://www.ducktoolkit.com/Home.jsp">Ducky Toolkit</a> site, or check out the Rubber Ducky script syntax from the official <a href="https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript">README</a></string>
+    <string name="duckhunter_label">HID Ducky Script Attacks</string>
+    <string name="select_language">Language</string>
+    <string name="duckConvertUpdate">Update</string>
+    <string name="duckConvertConvert">Convert</string>
+    <string name="duckPreviewRefresh">Refresh</string>
+    <string name="duck_hunter_headline">The DuckHunter script can easily convert "USB Rubber Ducky" scripts into NetHunter HID format.  You can generate preconfigured scripts at the incredibly useful <a href="http://www.ducktoolkit.com/Home.jsp">Ducky Toolkit</a> site, or check out the Rubber Ducky script syntax from the official <a href="https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript">README</a></string>
 
     <string name="iptables_label">Iptables Configuration</string>
     <string name="iptables_headline">Iptables Setup Config</string>
@@ -88,7 +88,10 @@
     <string name="update_kali_chroot">Update Kali chroot</string>
     <string name="turn_off_external_wifi">Turn Off External Wifi</string>
     <string name="shutdown_kali">Unmount Kali</string>
-    
+    <string name="add_button">Add a Button</string>
+
+    <string name="add_lauchner_btn_label">Button label: </string>
+    <string name="add_lauchner_btn_command">Command: </string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
@@ -99,7 +102,7 @@
     <string name="save">Save</string>
     <string name="execute">Execute</string>
     <string name="execute_attack">Execute Attack</string>
-    
+
     <string name="stop_mana">Stop mana</string>
     <string name="start_mana">Start mana</string>
     <string name="ip_address">IP address</string>
@@ -125,11 +128,13 @@
     <string name="get_external_ip">Get external IP</string>
     <string name="karma_loud">karma loud</string>
     <string name="dhcp_range">dhcp range</string>
-    
+
     <string name="ps_ip_address">IP Address (LHOST)</string>
     <string name="ps_port">Port (LPORT)</string>
     <string name="ps_payload_url">URL to payload</string>
 
+    <string name="toast_error_launcher">Invalid call of function!</string>
+    <string name="toast_input_error_launcher">Invalid arguments given!</string>
     <string name="toast_install_terminal">Error launching intent. Install Android Terminal!</string>
     <string name="descriptiontext" />
 

--- a/src/com/offsec/nethunter/KaliLauncherFragment.java
+++ b/src/com/offsec/nethunter/KaliLauncherFragment.java
@@ -1,23 +1,40 @@
 package com.offsec.nethunter;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.text.InputType;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
+
+import java.lang.reflect.Array;
+import java.util.List;
 
 //import android.app.Fragment;
 
 public class KaliLauncherFragment extends Fragment {
+
+    private SQLPersistence database;
+    private LayoutInflater inflater;
+
     /**
      * The fragment argument representing the section number for this
      * fragment.
      */
     private static final String ARG_SECTION_NUMBER = "section_number";
+
 
     /**
      * Returns a new instance of this fragment for the given section
@@ -26,7 +43,6 @@ public class KaliLauncherFragment extends Fragment {
 
 
     public KaliLauncherFragment() {
-
     }
 
     public static KaliLauncherFragment newInstance(int sectionNumber) {
@@ -40,20 +56,13 @@ public class KaliLauncherFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
+        database = new SQLPersistence(getActivity().getApplicationContext());
+        this.inflater = inflater;
 
         View rootView = inflater.inflate(R.layout.kali_launcher, container, false);
         addClickListener(R.id.button_start_kali, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c bootkali");
-                    startActivity(intent);
-                } catch (Exception e) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+                intentClickListener("bootkali");
             }
         }, rootView);
         /**
@@ -61,16 +70,7 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.button_start_kalimenu, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c 'bootkali kalimenu'");
-                    startActivity(intent);
-                } catch (Exception e) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+                intentClickListener("bootkali kalimenu");
             }
         }, rootView);
         /**
@@ -78,16 +78,7 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.update_kali_chroot, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c 'bootkali update'");
-                    startActivity(intent);
-                } catch (Exception e) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+                intentClickListener("bootkali update");
             }
         }, rootView);
         /**
@@ -95,34 +86,15 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.button_launch_wifite, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c 'bootkali wifite'");
-                    startActivity(intent);
-                } catch (Exception e) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+                intentClickListener("bootkali wifite");
             }
         }, rootView);
-
         /**
          * Turn off external wifi
          */
         addClickListener(R.id.turn_off_external_wifi, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c 'bootkali wifi-disable'");
-                    startActivity(intent);
-                } catch (Exception e) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+                intentClickListener("bootkali wifi-disable");
             }
         }, rootView);
         /**
@@ -130,18 +102,27 @@ public class KaliLauncherFragment extends Fragment {
          */
         addClickListener(R.id.shutdown_kali, new View.OnClickListener() {
             public void onClick(View v) {
-                try {
-                    Intent intent =
-                            new Intent("jackpal.androidterm.RUN_SCRIPT");
-                    intent.addCategory(Intent.CATEGORY_DEFAULT);
-                    intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c killkali");
-                    startActivity(intent);
-                } catch (android.content.ActivityNotFoundException anfe) {
-                    Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
-                    getTerminalApp();
-                }
+            intentClickListener("killkali");
             }
         }, rootView);
+        /**
+         * Add button
+         */
+        addClickListener(R.id.add_Button, new View.OnClickListener() {
+            public void onClick(View v) {
+                createNewButton();
+            }
+        }, rootView);
+
+        // load buttons from db
+        List<LauncherApp> apps = database.getAllApps();
+        for (LauncherApp app : apps) {
+            LauncherButton newButton = createButton(app.getBtn_label(), app.getCommand(), app.getId());
+            if (newButton != null) {
+                LinearLayout mainLayout = (LinearLayout) rootView.findViewById(R.id.launcher_layout);
+                mainLayout.addView(newButton);
+            }
+        }
         return rootView;
     }
 
@@ -159,9 +140,185 @@ public class KaliLauncherFragment extends Fragment {
         ((AppNavHomeActivity) activity).onSectionAttached(getArguments().getInt(ARG_SECTION_NUMBER));
     }
 
-
     private void addClickListener(int buttonId, View.OnClickListener onClickListener, View rootView) {
         rootView.findViewById(buttonId).setOnClickListener(onClickListener);
     }
 
+    private void addLongClickListener(int buttonId, View.OnLongClickListener onLongClickListener, View rootView) {
+        rootView.findViewById(buttonId).setOnLongClickListener(onLongClickListener);
+    }
+
+    private LauncherButton createButton(final String label, final String command, final long id) {
+
+        if (label.length() > 0 && command.length() > 0 && id != 0) {
+            final LauncherButton newButton = new LauncherButton(getActivity().getApplicationContext());
+
+            newButton.setWidth(LinearLayout.LayoutParams.FILL_PARENT);
+            newButton.setHeight(LinearLayout.LayoutParams.WRAP_CONTENT);
+            newButton.setText(label);
+            newButton.setDb_id(id);
+            newButton.setTextColor(Color.LTGRAY);
+            newButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    intentClickListener("bootkali custom_cmd " + command);
+                }
+            });
+
+            newButton.setOnLongClickListener(new View.OnLongClickListener() {
+
+                public boolean onLongClick(View view) {
+                    deleteUpdateButton(newButton);
+                    return true;
+                }
+            });
+            return newButton;
+        }
+        return null;
+    }
+
+    private void deleteButton(final LauncherButton button) {
+        if (button != null) {
+            LinearLayout mainLayout = (LinearLayout) getActivity().findViewById(R.id.launcher_layout);
+            button.setOnLongClickListener(null);
+            button.setOnClickListener(null);
+            mainLayout.removeView(button);
+        }
+    }
+
+    private void createNewButton() {
+
+        View promptsView = inflater.inflate(R.layout.newapplauncher, null);
+
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
+
+        alertDialogBuilder.setView(promptsView);
+
+        final EditText userInputBtnLabel= (EditText) promptsView
+                .findViewById(R.id.editText_launcher_btn_label);
+
+        final EditText userInputCommand = (EditText) promptsView
+                .findViewById(R.id.editText_launcher_command);
+
+        alertDialogBuilder
+                .setCancelable(false)
+                .setPositiveButton("OK",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                if (userInputBtnLabel.getText().length() > 0 &&
+                                        userInputCommand.getText().length() > 0) {
+
+                                    long db_id = database.addApp(userInputBtnLabel.getText().toString(),
+                                            userInputCommand.getText().toString());
+
+                                    LauncherButton newButton = createButton(userInputBtnLabel.getText().toString(),
+                                            userInputCommand.getText().toString(), db_id);
+
+                                    if (newButton != null) {
+                                        LinearLayout mainLayout = (LinearLayout) getActivity().findViewById(R.id.launcher_layout);
+                                        mainLayout.addView(newButton);
+                                    } else {
+                                        Toast.makeText(getActivity().getApplicationContext(),
+                                                getString(R.string.toast_error_launcher),
+                                                Toast.LENGTH_SHORT).show();
+                                    }
+
+                                } else {
+                                    Toast.makeText(getActivity().getApplicationContext(),
+                                            getString(R.string.toast_input_error_launcher),
+                                            Toast.LENGTH_SHORT).show();
+                                }
+                            }
+                        })
+                        .setNegativeButton("Cancel",
+                                new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int id) {
+                                        dialog.cancel();
+                                    }
+                                });
+        AlertDialog alertDialog = alertDialogBuilder.create();
+        alertDialog.show();
+    }
+
+    private void deleteUpdateButton(final LauncherButton button) {
+
+        final LauncherApp app = database.getApp(button.getDb_id());
+
+        View promptsView = inflater.inflate(R.layout.newapplauncher, null);
+
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getActivity());
+
+        alertDialogBuilder.setView(promptsView);
+
+        final EditText userInputBtnLabel= (EditText) promptsView
+                .findViewById(R.id.editText_launcher_btn_label);
+        userInputBtnLabel.setText(app.getBtn_label());
+
+        final EditText userInputCommand = (EditText) promptsView
+                .findViewById(R.id.editText_launcher_command);
+        userInputCommand.setText(app.getCommand());
+
+        alertDialogBuilder
+                .setCancelable(false)
+                .setPositiveButton("Update",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                if (userInputBtnLabel.getText().length() > 0 &&
+                                        userInputCommand.getText().length() > 0) {
+
+                                    database.updateApp(new LauncherApp(app.getId(),
+                                            userInputBtnLabel.getText().toString(),
+                                            userInputCommand.getText().toString()));
+
+                                    deleteButton(button);
+
+                                    LauncherButton newButton = createButton(userInputBtnLabel.getText().toString(),
+                                            userInputCommand.getText().toString(), app.getId());
+
+                                    if (newButton != null) {
+                                        LinearLayout mainLayout = (LinearLayout) getActivity().findViewById(R.id.launcher_layout);
+                                        mainLayout.addView(newButton);
+                                    } else {
+                                        Toast.makeText(getActivity().getApplicationContext(),
+                                                getString(R.string.toast_error_launcher),
+                                                Toast.LENGTH_SHORT).show();
+                                    }
+
+                                } else {
+                                    Toast.makeText(getActivity().getApplicationContext(),
+                                            getString(R.string.toast_input_error_launcher),
+                                            Toast.LENGTH_SHORT).show();
+                                }
+                            }
+                        })
+                .setNeutralButton("Delete",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                database.deleteApp(app.getId());
+                                deleteButton(button);
+                            }
+                        })
+                .setNegativeButton("Cancel",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                dialog.cancel();
+                            }
+                        });
+        AlertDialog alertDialog = alertDialogBuilder.create();
+        alertDialog.show();
+    }
+
+    private void intentClickListener(final String command) {
+        try {
+            Intent intent =
+                    new Intent("jackpal.androidterm.RUN_SCRIPT");
+            intent.addCategory(Intent.CATEGORY_DEFAULT);
+
+            intent.putExtra("jackpal.androidterm.iInitialCommand", "su -c " + command);
+            startActivity(intent);
+        } catch (Exception e) {
+            Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_install_terminal), Toast.LENGTH_SHORT).show();
+            getTerminalApp();
+        }
+    }
 }

--- a/src/com/offsec/nethunter/LauncherApp.java
+++ b/src/com/offsec/nethunter/LauncherApp.java
@@ -1,0 +1,48 @@
+/**
+ * Created by AnglerVonMur on 26.07.15.
+ */
+package com.offsec.nethunter;
+
+public class LauncherApp {
+
+    private long id;
+    private String btn_label;
+    private String command;
+
+    final static String TABLE = "LAUNCHERS";
+    final static String ID = "ID";
+    final static String BTN_LABEL = "BTN_LABEL";
+    final static String CMD = "COMMAND";
+    final static String[] COLUMNS = {ID,BTN_LABEL,CMD};
+
+    public LauncherApp() {
+    }
+
+    public LauncherApp(long id, String btn_name, String command) {
+        this.id = id;
+        this.btn_label = btn_name;
+        this.command = command;
+    }
+
+    public void setId(long id) { this.id = id; }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getBtn_label() {
+        return btn_label;
+    }
+
+    public void setBtn_label(String btn_label) {
+        this.btn_label = btn_label;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+}

--- a/src/com/offsec/nethunter/LauncherButton.java
+++ b/src/com/offsec/nethunter/LauncherButton.java
@@ -1,0 +1,24 @@
+/**
+ * Created by AnglerVonMur on 26.07.15.
+ */
+package com.offsec.nethunter;
+
+import android.content.Context;
+import android.widget.Button;
+
+public class LauncherButton extends Button {
+
+    private long db_id;
+
+    public LauncherButton(Context context) {
+        super(context);
+    }
+
+    public long getDb_id() {
+        return db_id;
+    }
+
+    public void setDb_id(long db_id) {
+        this.db_id = db_id;
+    }
+}

--- a/src/com/offsec/nethunter/SQLPersistence.java
+++ b/src/com/offsec/nethunter/SQLPersistence.java
@@ -1,0 +1,131 @@
+/**
+ * Created by AnglerVonMur on 26.07.15.
+ */
+package com.offsec.nethunter;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.util.Log;
+import java.util.LinkedList;
+import java.util.List;
+
+public class SQLPersistence extends SQLiteOpenHelper {
+
+    final static int DATABASE_VERSION = 1;
+    final static String DATABASE_NAME = "KaliLaunchers";
+
+    final static String CREATE_LAUNCHER_TABLE = "CREATE TABLE " +
+            LauncherApp.TABLE + " (" +
+            LauncherApp.ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            LauncherApp.BTN_LABEL + " TEXT, " +
+            LauncherApp.CMD + " TEXT )";
+
+    public SQLPersistence(Context context) {
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(CREATE_LAUNCHER_TABLE);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        db.execSQL("DROP TABLE IF EXISTS");
+        this.onCreate(db);
+    }
+
+    public long addApp(final String btn_name, final String command) {
+        long id = 0;
+        if (btn_name.length() > 0 &&
+                command.length() > 0) {
+
+            SQLiteDatabase db = this.getWritableDatabase();
+
+            ContentValues values = new ContentValues();
+            values.put(LauncherApp.BTN_LABEL, btn_name);
+            values.put(LauncherApp.CMD, command);
+
+            id = db.insert(LauncherApp.TABLE, null, values);
+            db.close();
+        }
+        return id;
+    }
+
+    public List<LauncherApp> getAllApps() {
+        List<LauncherApp> apps = new LinkedList<LauncherApp>();
+        String query = "SELECT  * FROM " + LauncherApp.TABLE;
+
+        SQLiteDatabase db = this.getWritableDatabase();
+        Cursor cursor = db.rawQuery(query, null);
+
+        LauncherApp app = null;
+        if (cursor.moveToFirst()) {
+            do {
+                app = new LauncherApp();
+                app.setId(Long.parseLong(cursor.getString(0)));
+                app.setBtn_label(cursor.getString(1));
+                app.setCommand(cursor.getString(2));
+                apps.add(app);
+            } while (cursor.moveToNext());
+        }
+        return apps;
+    }
+
+
+    public LauncherApp getApp(final long id) {
+        LauncherApp app = null;
+        if (id != 0) {
+            SQLiteDatabase db = this.getReadableDatabase();
+
+            Cursor cursor =
+                    db.query(LauncherApp.TABLE,
+                            LauncherApp.COLUMNS,
+                            " id = ?",
+                            new String[]{String.valueOf(id)},
+                            null,
+                            null,
+                            null,
+                            null);
+
+            if (cursor != null)
+                cursor.moveToFirst();
+
+            app = new LauncherApp();
+            app.setId(Long.parseLong(cursor.getString(0)));
+            app.setBtn_label(cursor.getString(1));
+            app.setCommand(cursor.getString(2));
+        }
+        return app;
+    }
+
+    public void updateApp(final LauncherApp app) {
+        if (app != null) {
+            SQLiteDatabase db = this.getWritableDatabase();
+
+            ContentValues values = new ContentValues();
+            values.put(LauncherApp.BTN_LABEL, app.getBtn_label());
+            values.put(LauncherApp.CMD, app.getCommand());
+
+            db.update(LauncherApp.TABLE, values,
+                    LauncherApp.ID + " = ?",
+                    new String[]{String.valueOf(app.getId())});
+
+            db.close();
+        }
+    }
+
+    public void deleteApp(final long id) {
+        if (id != 0) {
+            SQLiteDatabase db = this.getWritableDatabase();
+
+            db.delete(LauncherApp.TABLE, LauncherApp.ID + " = ?",
+                    new String[]{String.valueOf(id)});
+
+            db.close();
+        }
+    }
+}


### PR DESCRIPTION
Hi, I want to share my new feature of nethunter-app. This feature includes custom buttons for Kali Launcher. You can easily create a new button and assign a command, for example nmap –sS <IP>/24. This button will be stored in the sql lite database on the device. The command will be executed in Kali Shell ;). If you long click the button you can change or delete it. This is the first version, maybe you need this feature in future.

You need some modifications in bootkali script, read README first.
