### PR TITLE
Now the service is responsive, but stills trows.

### DIFF
--- a/src/com/offsec/nethunter/KaliServicesFragment.java
+++ b/src/com/offsec/nethunter/KaliServicesFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,7 +66,7 @@ public class KaliServicesFragment extends Fragment {
                     {"Metasploit", "sh " + fileDir + "/check-kalimetasploit", "su -c '" + fileDir + "/bootkali msf start'", "su -c '" + fileDir + "/bootkali msf stop'"},
                     //{"DHCP", "sh " + fileDir + "/check-kalidhcp","su -c '" + cachedir + "/bootkali dhcp start'","su -c '" + cachedir + "/bootkali dhcp stop'"},
                     {"BeEF Framework", "sh " + fileDir + "/check-kalibeef-xss", "su -c '" + fileDir + "/bootkali beef-xss start'", "su -c '" + fileDir + "/bootkali beef-xss stop'"},
-                    {"Y-cable Charging", "sh /system/xbin/check-ycable","su -c 'bootkali ycable start'","su -c 'bootkali ycable stop'"},
+                    {"Y-cable Charging", "sh " + fileDir + "/check-ycable","su -c 'bootkali ycable start'","su -c 'bootkali ycable stop'"},
                     //{"Fruity WiFi", "sh " + fileDir + "/check-fruity-wifi","su -c start-fruity-wifi","su -c  stop-fruity-wifi"}
                     // the stop script isnt working well, doing a raw cmd instead to stop vnc
                     // {"VNC", "sh " + fileDir + "/check-kalivnc", "" + cachedir + "/bootkali\nvncserver", "" + cachedir + "/bootkali\nkill $(ps aux | grep 'Xtightvnc' | awk '{print $2}');CT=0;for x in $(ps aux | grep 'Xtightvnc' | awk '{print $2}'); do CT=$[$CT +1];tightvncserver -kill :$CT; done;rm /root/.vnc/*.log;rm -r /tmp/.X*"},
@@ -177,7 +178,6 @@ class SwichLoader extends BaseAdapter {
         // clear state
         vH.sw.setChecked(false);
         // check it
-
         if (position>=curstats.length) {
             return convertView;
         }


### PR DESCRIPTION
Corrected the location of the  `check-ycable` script, now the service is responsive, but stills trows.

    E/Shell Error:: /data/data/com.offsec.nethunter/files/scripts/check-ycable[3]:
    cat: /sys/module/tegra_otg/parameters/tegra_otg_on_charging: No such file or directory
    E/Shell Error:: /data/data/com.offsec.nethunter/files/scripts/check-ycable[4]:
    cat: /sys/module/dwc3/parameters/aca_enable: No such file or directory

Tested at N5.

Maybe bootkali needs some tunning.