### PR TITLE
Missed a if clausule, it prevents the chroot metapackages from install, causing a null pointer.

### DIFF
--- a/src/com/offsec/nethunter/ChrootManagerFragment.java
+++ b/src/com/offsec/nethunter/ChrootManagerFragment.java
@@ -359,11 +359,8 @@ public class ChrootManagerFragment extends Fragment {
             Intent intent =
                     new Intent("com.offsec.nhterm.RUN_SCRIPT_NH");
             intent.addCategory(Intent.CATEGORY_DEFAULT);
-            if(packages.equals("")){
-                intent.putExtra("com.offsec.nhterm.iInitialCommand", "apt-get install " + packages);
-            }
-            //
-            //  Log.d("PACKS:", "PACKS:" + packages);
+            intent.putExtra("com.offsec.nhterm.iInitialCommand", "apt-get install " + packages);
+            Log.d("PACKS:", "PACKS:" + packages);
             startActivity(intent);
         } catch (Exception e) {
             nh.showMessage(getString(R.string.toast_install_terminal));


### PR DESCRIPTION
Fix for https://github.com/offensive-security/kali-nethunter/issues/292