### PR TITLE
Add possibility to have one 'letter' need multiple commands and add an 'enter' command even if there isn't any newline after 'STRING''

### DIFF
--- a/assets/nh_files/modules/duckhunter.py
+++ b/assets/nh_files/modules/duckhunter.py
@@ -267,9 +267,7 @@ if __name__ == "__main__":
             line = line[7:]
             for char in line:
 
-                if char == '\n':  # Add enter if new line automagically
-                    dest.write('echo enter | hid-keyboard /dev/hidg0 keyboard\n')
-                else:
+                if char != '\n':
                     if args.layout == "ru":
                         char = iso_ru[char]
 
@@ -285,6 +283,8 @@ if __name__ == "__main__":
                         dest.write('%s%s%s\n' % (prefixinput, line.rstrip('\n').strip(), prefixoutput))
                         dest.write('echo -ne "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00" > /dev/hidg0\n') # releases key
                         dest.write('sleep 0.03 \n') # Slow things down
+
+            dest.write('echo enter | hid-keyboard /dev/hidg0 keyboard\n') # Add enter
 
         # TEXT to type and NOT pass \n as ENTER.  Allows text to stay put.
         elif line.startswith('TEXT '):

--- a/assets/nh_files/modules/duckhunter.py
+++ b/assets/nh_files/modules/duckhunter.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
             line = line[7:]
             for char in line:
 
-                if char == "\n":  # Add enter if new line automagically
+                if char == '\n':  # Add enter if new line automagically
                     dest.write('echo enter | hid-keyboard /dev/hidg0 keyboard\n')
                 else:
                     if args.layout == "ru":
@@ -275,7 +275,11 @@ if __name__ == "__main__":
 
                     line = dicts[args.layout+'_bin'].get(char)
                     if line is not None:
-                        dest.write('%s%s%s\n' % (prefix, line.rstrip('\n').strip(), suffix))
+                        if isinstance(line, str):
+                            dest.write('%s%s%s\n' % (prefix, line.rstrip('\n').strip(), suffix))
+                        else:
+                            for elem in line:
+                                dest.write('%s%s%s\n' % (prefix, elem.rstrip('\n').strip(), suffix))
                     else:
                         line = dicts[args.layout][char]
                         dest.write('%s%s%s\n' % (prefixinput, line.rstrip('\n').strip(), prefixoutput))
@@ -294,7 +298,11 @@ if __name__ == "__main__":
 
                     line = dicts[args.layout+'_bin'].get(char)
                     if line is not None:
-                        dest.write('%s%s%s\n' % (prefix, line.rstrip('\n').strip(), suffix))
+                        if isinstance(line, str):
+                            dest.write('%s%s%s\n' % (prefix, line.rstrip('\n').strip(), suffix))
+                        else:
+                            for elem in line:
+                                dest.write('%s%s%s\n' % (prefix, elem.rstrip('\n').strip(), suffix))
                     else:
                         line = dicts[args.layout][char]
                         dest.write('%s%s%s\n' % (prefixinput, line.rstrip('\n').strip(), prefixoutput))

--- a/assets/nh_files/modules/keyseed.py
+++ b/assets/nh_files/modules/keyseed.py
@@ -288,7 +288,7 @@ dicts = {
         "\x5d": "right-alt minus", # ]
         "\x5e": "right-alt 9",     # ^
         "\x5f": "8",               # _
-        "\x60": "right-alt 7",     # `
+        "\x60": ["right-alt 7", "space"], # `
         # Lowercase
         "\x61": "q",
         "\x62": "b",
@@ -320,7 +320,7 @@ dicts = {
         "\x7b": "right-alt 4",      # {
         "\x7c": "right-alt 6",      # |
         "\x7d": "right-alt equals", # }
-        "\x7e": "right-alt 2",      # ~
+        "\x7e": ["right-alt 2", "space"], # ~
         "\x7f": "backspace",
         #SDLK_RETURN,0x28
         #"\x0a": "\\x00\\x00\\x00\\x28\\x00\\x00\\x00\\x00",


### PR DESCRIPTION
For example, in french layout, the character \` needs a space to be put alone whitout changing the next one, for example you can try to type that \`a it will give you that character: à
not what you typed, and this PR fixes that.