### PR TITLE
Change button name to 'Attack' instead of 'Convert' in DuckHunter interface

### DIFF
--- a/res/menu/duck_hunter.xml
+++ b/res/menu/duck_hunter.xml
@@ -2,9 +2,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/duckConvertConvert"
+        android:id="@+id/duckConvertAttack"
         android:icon="@drawable/ic_action_play"
-        android:title="@string/duckConvertConvert"
+        android:title="@string/duckConvertAttack"
         app:showAsAction="ifRoom|withText"  />
 	<item
         android:id="@+id/chooseLanguage"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -50,9 +50,7 @@
 
     <string name="duckhunter_label">HID Ducky Script Attacks</string>
     <string name="select_language">Language</string>
-    <string name="duckConvertUpdate">Update</string>
-    <string name="duckConvertConvert">Convert</string>
-    <string name="duckPreviewRefresh">Refresh</string>
+    <string name="duckConvertAttack">Attack</string>
     <string name="duck_hunter_headline">The DuckHunter script can easily convert "USB Rubber Ducky" scripts into NetHunter HID format.  You can generate preconfigured scripts at the incredibly useful <a href="http://www.ducktoolkit.com/Home.jsp">Ducky Toolkit</a> site, or check out the Rubber Ducky script syntax from the official <a href="https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript">README</a></string>
     <string-array name="duckhunter_preset_array">
         <item>Select preset</item>

--- a/src/com/offsec/nethunter/DuckHunterFragment.java
+++ b/src/com/offsec/nethunter/DuckHunterFragment.java
@@ -109,9 +109,9 @@ public class DuckHunterFragment extends Fragment implements ActionBar.TabListene
     public void onPrepareOptionsMenu(Menu menu) {
         int pageNum = mViewPager.getCurrentItem();
         if (pageNum == 0) {
-            menu.findItem(R.id.duckConvertConvert).setVisible(true);
+            menu.findItem(R.id.duckConvertAttack).setVisible(true);
         } else {
-            menu.findItem(R.id.duckConvertConvert).setVisible(false);
+            menu.findItem(R.id.duckConvertAttack).setVisible(false);
         }
         getActivity().invalidateOptionsMenu();
     }
@@ -159,7 +159,7 @@ public class DuckHunterFragment extends Fragment implements ActionBar.TabListene
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.duckConvertConvert:
+            case R.id.duckConvertAttack:
                 setLang();
                 nh.showMessage("Launching Attack");
                 if(getView() == null){


### PR DESCRIPTION
Could you please check that it works correctly (e.g. that I didn't forget anywhere to change the name).