### PR TITLE
Update sdcard/disk mounting to work in Marshmallow+

### DIFF
--- a/assets/scripts/bootkali_init
+++ b/assets/scripts/bootkali_init
@@ -74,29 +74,80 @@ chmod 644 $mnt/etc/resolv.conf
 ## Should run always (https://su.chainfire.eu/#how-mount)
 $busybox mount -o remount,suid /data
 
+mount_sdcard() {
+	mountpoint -q "$mnt/sdcard" && return 0
+
+	for sdcard in \
+		"$EXTERNAL_STORAGE" \
+		/storage/emulated/0 \
+		/storage/emulated/legacy \
+		/storage/sdcard0 \
+		/sdcard
+	do
+		$busybox mountpoint -q "$sdcard" &&
+			$busybox mount -o bind "$sdcard" "$mnt/sdcard" &&
+				return 0
+	done
+	return 1
+}
+
+mount_external_sd() {
+	mountpoint -q "$mnt/external_sd" && return 0
+
+	for external_sd in \
+		/storage/extSdCard \
+		/storage/sdcard1 \
+		/storage/external_sd \
+		/external_sd
+	do
+		$busybox mountpoint -q "$external_sd" &&
+			$busybox mount -o bind "$external_sd" "$mnt/external_sd" &&
+				return 0
+	done
+	return 1
+}
+
+mount_usbdisk() {
+	mountpoint -q "$mnt/mnt/usbdisk" && return 0
+
+	for usbdisk in /storage/usb*; do
+		$busybox mountpoint -q "$usbdisk" &&
+			$busybox mount -o bind "$usbdisk" "$mnt/mnt/usbdisk" &&
+				return 0
+	done
+	return 1
+}
+
+mount_external_storage() {
+	mount_external_sd && external_sd_mounted=true
+	mount_usbdisk && usbdisk_mounted=true
+
+	# try marshmallow storage names
+	for storage in /storage/*-*; do
+		# if both mount successfully then skip
+		$external_sd_mounted && $usbdisk_mounted && return
+
+		if $busybox mountpoint -q "$storage"; then
+			if ! $external_sd_mounted; then
+				$busybox mount -o bind "$storage" "$mnt/external_sd" &&
+					external_sd_mounted=true
+			elif ! $usbdisk_mounted; then
+				$busybox mount -o bind "$storage" "$mnt/usbdisk" &&
+					usbdisk_mounted=true
+			fi
+		fi
+	done
+}
+
 # If chroot's /dev is mounted, assume the chroot is already running and skip initialization
 if ! $busybox mountpoint -q $mnt/dev; then
 	f_checkforroot
 
 	$busybox mount -r -o bind /system $mnt/system
 
-	if $busybox mountpoint -q "$EXTERNAL_STORAGE"; then
-		$busybox mount -o bind "$EXTERNAL_STORAGE" $mnt/sdcard
-	elif $busybox mountpoint -q /storage/emulated/0; then
-		$busybox mount -o bind /storage/emulated/0 $mnt/sdcard
-	elif $busybox mountpoint -q /storage/emulated/legacy; then
-		$busybox mount -o bind /storage/emulated/legacy $mnt/sdcard
-	else
-		$busybox mount -o bind /sdcard $mnt/sdcard
-	fi
+	mount_sdcard
+	mount_external_storage
 
-	# Grab the first available secondary storage and assume it's a micro SDcard
-	SDCARD=$(echo "$SECONDARY_STORAGE" | $busybox cut -d: -f1)
-	if $busybox mountpoint -q "$SDCARD"; then
-		$busybox mount -o bind "$SDCARD" $mnt/external_sd
-	fi
-
-	$busybox mount -o bind /storage/usbdisk $mnt/mnt/usbdisk
 	$busybox mount -o bind /dev $mnt/dev
 	$busybox mount -t devpts devpts $mnt/dev/pts
 	$busybox mount -t proc proc $mnt/proc


### PR DESCRIPTION
Not entirely sure if this is working, will need a test build.

In the case of XXXX-XXXX naming only we have no way to distinguish between microSD and USB OTG, so we'll just mount the first match to external_sd and the second match to usbdisk.