### PR TITLE
FIXED Issue #742

### DIFF
--- a/assets/nh_files/modules/keyseed.py
+++ b/assets/nh_files/modules/keyseed.py
@@ -528,6 +528,8 @@ dicts = {
         "\x0d": "\\x00\\x00\\x00\\x28\\x00\\x00\\x00\\x00"
     },
     'de_bin' : {
+        "\x47": "left-shift g",
+        "\x67": "g",
     },
     'de' : {
         # Symbols


### PR DESCRIPTION
Duckhunter - Letter "g" or "G" not send to Windows 7 (DE) 
https://github.com/offensive-security/kali-nethunter/issues/742

Now sending every letter and sign correctly