### PR TITLE
Fix bootkali_init su call for Magisk

### DIFF
--- a/assets/scripts/bootkali_init
+++ b/assets/scripts/bootkali_init
@@ -18,7 +18,7 @@ else
 	exit 1
 fi
 
-su 0 setenforce 0
+su -c setenforce 0
 
 ######### CHECK FOR ROOT #########
 f_checkforroot(){


### PR DESCRIPTION
If rooting device with Magisk, line #21 fails - causing the Terminal to hang. This is due to su waiting for input. The common symptom of this is seen when launching the Nethunter Kali Terminal - it will drop into normal Android Terminal until you type 'exit'. This fix, the su -c command, will work with both SuperSu and Magisk