### PR TITLE
Update build tools / move builder's name to build.gradle rather than in activity.

### DIFF
--- a/androidwversionmanager/build.gradle
+++ b/androidwversionmanager/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '26.0.2'
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
@@ -27,6 +27,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:26.0.1'
+    compile 'com.android.support:support-v4:26.1.0'
     compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
     }
 }
 
@@ -22,20 +22,20 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:26.0.1'
-    compile 'com.android.support:appcompat-v7:26.0.1'
-    compile 'com.android.support:design:26.0.1'
+    compile 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:design:26.1.0'
     compile project(':androidwversionmanager')
     compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
-    compile 'com.google.android.gms:play-services-location:11.2.0'
-    compile 'joda-time:joda-time:2.9.7'
-    implementation 'com.google.guava:guava:23.0-android'
+    compile 'com.google.android.gms:play-services-location:11.4.2'
+    compile 'joda-time:joda-time:2.9.9'
+    implementation 'com.google.guava:guava:23.2-android'
 }
 
 android {
 
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '26.0.2'
 
     dataBinding {
         enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ android {
             minifyEnabled false
             buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + System.currentTimeMillis() + "L)"
             buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\""
-
             return true
         }
         release {
@@ -107,8 +106,10 @@ android {
             jniDebuggable false
             zipAlignEnabled true
             buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + System.currentTimeMillis() + "L)"
-            buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\""
-
+            /*  enable below to set "built by" name to build machine name
+                buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\""
+                or change line below to hard code it.  */
+            buildConfigField "String", "BUILD_NAME", "\"Kali\""
             return true
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,4 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-rc-1-all.zip

--- a/src/com/offsec/nethunter/AppNavHomeActivity.java
+++ b/src/com/offsec/nethunter/AppNavHomeActivity.java
@@ -115,8 +115,7 @@ public class AppNavHomeActivity extends AppCompatActivity implements KaliGPSUpda
         TextView buildInfo1 = (TextView) navigationHeadView.findViewById(R.id.buildinfo1);
         TextView buildInfo2 = (TextView) navigationHeadView.findViewById(R.id.buildinfo2);
         buildInfo1.setText(String.format("Version: %s (%s)", BuildConfig.VERSION_NAME, Build.TAGS));
-        String buildUser = "Kali";
-        buildInfo2.setText(String.format("Built by %s at %s", buildUser, buildTime));
+        buildInfo2.setText(String.format("Built by %s at %s", BuildConfig.BUILD_NAME, buildTime));
 
         if (navigationView != null) {
             setupDrawerContent(navigationView);


### PR DESCRIPTION
Just did a fresh build so updated libraries and tools.  Also saw that the builder was hard-coded, so moved that to build.gradle.  Debug builds will use the build machine users' name, but release names will use the harcoded name w/quotes--  so should look like:

Built by "Kali" at...

(inc. quotes around Kali).  If you don't want the quotes, it's an easy change.  Or if you want it hard coded in the actual code, that's fine too.  Just passing this all along as usual.  Didn't notice it break anything, but YMMV.