### PR TITLE
Update to RunAtBoot for Android O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ libsuperuser-release/libsuperuser-release.iml
 androidwversionmanager/androidwversionmanager.iml
 *.iml
 /release
+
+/res/values/secrets.xml
+signing.properties

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -86,6 +86,7 @@
         <service
             android:name=".service.RunAtBootService"
             android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:process=":runAtBoot" />
         <service
             android:name="gps.LocationUpdateService"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -382,6 +382,9 @@
     <string name="inject_settings">Inject Settings</string>
     <!-- End GPSFragment -->
 
+    <!--Notification Channel-->
+    <string name="boot_notification_channel">Boot</string>
+    <string name="boot_notification_channel_description">Notification for run at boot services</string>
 
 
     <!-- TODO: Remove or change this placeholder text -->

--- a/src/com/offsec/nethunter/AppNavHomeActivity.java
+++ b/src/com/offsec/nethunter/AppNavHomeActivity.java
@@ -2,6 +2,8 @@ package com.offsec.nethunter;
 
 import android.Manifest;
 import android.app.AlertDialog;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -45,7 +47,8 @@ public class AppNavHomeActivity extends AppCompatActivity implements KaliGPSUpda
 
     public final static String TAG = "AppNavHomeActivity";
     private static final String CHROOT_INSTALLED_TAG = "CHROOT_INSTALLED_TAG";
-    private static final String GPS_BACKGROUND_FRAGMENT_TAG = "BG_FRAGMENT_TAG";
+    private static final String GPS_BACKGROUND_FRAGMENT_TAG = "BG_FRAGMENT_TAG"
+    public static final String BOOT_CHANNEL_ID = "BOOT_CHANNEL";
 
     /**
      * Fragment managing the behaviors, interactions and presentation of the navigation drawer.
@@ -164,6 +167,23 @@ public class AppNavHomeActivity extends AppCompatActivity implements KaliGPSUpda
         mDrawerToggle.syncState();
         // pre-set the drawer options
         setDrawerOptions();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create the NotificationChannel
+            CharSequence name = getString(R.string.boot_notification_channel);
+            String description = getString(R.string.boot_notification_channel_description);
+            int importance = NotificationManager.IMPORTANCE_LOW;
+            NotificationChannel mChannel = new NotificationChannel(BOOT_CHANNEL_ID, name, importance);
+            mChannel.setDescription(description);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = (NotificationManager) getSystemService(
+                    NOTIFICATION_SERVICE);
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(mChannel);
+            }
+        }
+
 
     }
 

--- a/src/com/offsec/nethunter/receiver/BootCompletedReceiver.java
+++ b/src/com/offsec/nethunter/receiver/BootCompletedReceiver.java
@@ -6,15 +6,12 @@ import android.content.Intent;
 
 import com.offsec.nethunter.service.RunAtBootService;
 
-/**
- * Created by fattire on 2/19/15.
- */
-
 public class BootCompletedReceiver extends BroadcastReceiver{
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            Intent startServiceIntent = new Intent(context, RunAtBootService.class);
-            context.startService(startServiceIntent);
+            if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+                RunAtBootService.enqueueWork(context, new Intent());
+            }
         }
 }

--- a/src/com/offsec/nethunter/service/RunAtBootService.java
+++ b/src/com/offsec/nethunter/service/RunAtBootService.java
@@ -7,9 +7,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.IBinder;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.offsec.nethunter.AppNavHomeActivity;
 import com.offsec.nethunter.ChrootManagerFragment;
 import com.offsec.nethunter.KaliServicesFragment;
 import com.offsec.nethunter.R;
@@ -17,36 +21,42 @@ import com.offsec.nethunter.utils.NhPaths;
 import com.offsec.nethunter.utils.ShellExecuter;
 
 
-public class RunAtBootService extends Service {
+public class RunAtBootService extends JobIntentService {
     private static final String CHROOT_INSTALLED_TAG = "CHROOT_INSTALLED_TAG";
     private static final String TAG = "Nethunter: Startup";
+    private static final int JOB_ID = 1;
     private final ShellExecuter x = new ShellExecuter();
     private NhPaths nh;
     private Boolean runBootServices = true;
     private String doing_action = "";
-    private Notification.Builder n = null;
+    private NotificationCompat.Builder n = null;
 
     public RunAtBootService() {
     }
 
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, RunAtBootService.class, JOB_ID, work);
+    }
+
+
     private void doNotification(String contents) {
         if (n == null) {
-            n = new Notification.Builder(this);
+            n = new NotificationCompat.Builder(this, AppNavHomeActivity.BOOT_CHANNEL_ID);
         }
-        n.setStyle(new Notification.BigTextStyle().bigText(contents))
+        n.setStyle(new NotificationCompat.BigTextStyle().bigText(contents))
                 .setContentTitle(RunAtBootService.TAG)
-                //.setContentText(contents)
                 .setSmallIcon(R.drawable.ic_stat_ic_nh_notificaiton)
-                // .setContentIntent(pIntent)
                 .setAutoCancel(true);
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 
-        notificationManager.notify(999, n.build());
+        if (notificationManager != null) {
+            notificationManager.notify(999, n.build());
+        }
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
+    protected void onHandleWork(@NonNull Intent intent) {
         doNotification("Doing boot checks");
         nh = new NhPaths(getFilesDir().toString());
         SharedPreferences sharedpreferences = getSharedPreferences("com.offsec.nethunter", Context.MODE_PRIVATE);
@@ -122,24 +132,17 @@ public class RunAtBootService extends Service {
         }
 
         if (userinit(runBootServices)) {
-            Toast.makeText(getBaseContext(), "Boot end: ALL OK", Toast.LENGTH_SHORT).show();
-//            doNotification("Boot ended. All fine. Action performed: " + doing_action + " OK");
+//            Toast.makeText(getBaseContext(), "Boot end: ALL OK", Toast.LENGTH_SHORT).show();
+            doNotification("Boot ended. All fine. Action performed: " + doing_action + " OK");
         } else {
             if (!runBootServices) {
-                Toast.makeText(getBaseContext(), "Not runing boot scripts. OK", Toast.LENGTH_SHORT).show();
-//                doNotification("Boot ended. All fine. Action performed: " + doing_action + " OK");
+//                Toast.makeText(getBaseContext(), "Not runing boot scripts. OK", Toast.LENGTH_SHORT).show();
+                doNotification("Boot ended. All fine. Action performed: " + doing_action + " OK");
             } else {
                 doNotification("Boot ended. No busybox found!");
             }
         }
         // put change MAC addresses here.
-        stopSelf();
-        return super.onStartCommand(intent, flags, startId);
-    }
-
-    @Override
-    public IBinder onBind(Intent intent) {
-        return null; // don't support binding for now.
     }
 
     private boolean userinit(Boolean ShouldRun) {
@@ -159,7 +162,7 @@ public class RunAtBootService extends Service {
             // init.d
             String[] runner = {busybox + " run-parts " + nh.APP_INITD_PATH};
             exe.RunAsRoot(runner);
-            Toast.makeText(getBaseContext(), getString(R.string.autorunningscripts), Toast.LENGTH_SHORT).show();
+//            Toast.makeText(getBaseContext(), getString(R.string.autorunningscripts), Toast.LENGTH_SHORT).show();
             return true;
         }
         Toast.makeText(getBaseContext(), getString(R.string.toastForNoBusybox), Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
Changed runatboot service and associated notifications to update for Android Oreo. I believe this fixes issue #178. Permissions changed in O to require BIND_JOB_SERVICE, and also to use a JobIntentService. Notifications also changed, as indicated in the code.

This breaks the toast functionality from the service when all boot actions are complete, but it still shows in the notification, so I think this should be acceptable.

Haven't tested < Android O.