### PR TITLE
Add white titles to "custom Commands" items and add items to the Duckhunter "Spinner"

### DIFF
--- a/res/layout/custom_commands_item.xml
+++ b/res/layout/custom_commands_item.xml
@@ -15,7 +15,8 @@
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:gravity="center_vertical"
-        android:layout_alignBottom="@+id/runCommand" />
+        android:layout_alignBottom="@+id/runCommand"
+        android:textColor="#FFFFFF" />
 
     <TextView
         android:layout_width="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,6 +45,7 @@
         <item>Hello World</item>
         <item>OSX Perl Reverse Shell</item>
         <item>OSX Ruby Reverse Shell</item>
+        <item>Windowews RDP</item>
         <item>Fake Windows 10 Update</item>
     </string-array>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,6 +45,7 @@
         <item>Hello World</item>
         <item>OSX Perl Reverse Shell</item>
         <item>OSX Ruby Reverse Shell</item>
+        <item>Fake Windows 10 Update</item>
     </string-array>
 
     <string name="payload_select">Please select</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,7 +45,7 @@
         <item>Hello World</item>
         <item>OSX Perl Reverse Shell</item>
         <item>OSX Ruby Reverse Shell</item>
-        <item>Windowews RDP</item>
+        <item>Enable Windows RDP</item>
         <item>Fake Windows 10 Update</item>
     </string-array>
 


### PR DESCRIPTION
The title in Custom command was black and it was had to see it well so I change it to white.
I add the duckyscript windows_rdp and the FakeUpdateWin10 to the "spinner" to be able the select them as presets.