### PR TITLE
Mount fixes

### DIFF
--- a/assets/scripts/bootkali_init
+++ b/assets/scripts/bootkali_init
@@ -71,21 +71,21 @@ mount_sdcard() {
 	return 1
 }
 
-mount_external_sd() {
-	mountpoint -q "$mnt/external_sd" && return 0
-
-	for external_sd in \
-		/storage/extSdCard \
-		/storage/sdcard1 \
-		/storage/external_sd \
-		/external_sd
-	do
-		[ -d "$external_sd" ] &&
-			$busybox mount -o bind "$external_sd" "$mnt/external_sd" &&
-				return 0
-	done
-	return 1
-}
+#mount_external_sd() {
+#	mountpoint -q "$mnt/external_sd" && return 0
+#
+#	for external_sd in \
+#		/storage/extSdCard \
+#		/storage/sdcard1 \
+#		/storage/external_sd \
+#		/external_sd
+#	do
+#		[ -d "$external_sd" ] &&
+#			$busybox mount -o bind "$external_sd" "$mnt/external_sd" &&
+#				return 0
+#	done
+#	return 1
+#}
 
 mount_usbdisk() {
 	mountpoint -q "$mnt/mnt/usbdisk" && return 0
@@ -174,7 +174,7 @@ mount_kali_chroot() {
     if [ ! "$(mountpoint $mnt/dev/pts 2> /dev/null | grep 'is a')" ]; then
         $busybox mount -t devpts devpts $mnt/dev/pts && bklog "[+] mounted /dev/pts"
     fi
-    
+
     ######### MOUNT DEV SHM ########
     if [ ! "$(mountpoint $mnt/dev/shm 2> /dev/null | grep 'is a')" ]; then
         $busybox mount -t tmpfs tmpfs $mnt/dev/shm && bklog "[+] mounted /dev/shm"
@@ -186,7 +186,7 @@ mount_kali_chroot() {
         $busybox mount -t proc proc $mnt/proc && bklog "[+] mounted /proc"
     fi
 
-  	######### MOUNT SYS ########
+    ######### MOUNT SYS #########
     if [ ! "$(mountpoint $mnt/sys 2> /dev/null | grep 'is a')" ]; then
         [ ! -d $mnt/sys ] && mkdir -p $mnt/sys
         $busybox mount -t sysfs sys $mnt/sys && bklog "[+] mounted /sys"
@@ -198,14 +198,14 @@ mount_kali_chroot() {
         $busybox mount -r -o bind /system $mnt/system && bklog "[+] mounted /system"
     fi
 
-    #enable depmod/modprobe support in rootfs
+    # Enable depmod/modprobe support in rootfs
     if [ ! "$(mountpoint $mnt/lib/modules 2> /dev/null | grep 'is a')" ]; then
        $busybox mount -r -o bind /system/lib/modules $mnt/lib/modules && bklog "[+] mounted /lib/modules"
     fi
 
     ######### MOUNT INTERNAL | EXTERNAL SDCARD | USBDISK ########
     mount_sdcard
-    mount_external_sd
+    #mount_external_sd
 
     #########
     $busybox chmod 666 /dev/null

--- a/assets/scripts/get-keyring
+++ b/assets/scripts/get-keyring
@@ -1,0 +1,8 @@
+#!/system/bin/sh
+
+echo "* Setting up the APT keyring (downloading & install)"
+curl -O https://http.kali.org/pool/main/k/kali-archive-keyring/kali-archive-keyring_2018.1_all.deb
+dpkg -i *.deb
+rm -rf *.deb
+clear
+apt-get update

--- a/assets/scripts/killkali
+++ b/assets/scripts/killkali
@@ -17,7 +17,7 @@ else
 fi
 
 export bin=/system/bin
-#export mnt=/data/local/nhsystem/kali-armhf
+export mnt=/data/local/nhsystem/kali-armhf
 PRESERVED_PATH=$PATH
 export PATH=/usr/bin:/usr/sbin:/bin:/usr/local/bin:/usr/local/sbin:$PATH
 export TERM=linux

--- a/assets/scripts/killkali
+++ b/assets/scripts/killkali
@@ -17,7 +17,7 @@ else
 fi
 
 export bin=/system/bin
-export mnt=/data/local/nhsystem/kali-armhf
+#export mnt=/data/local/nhsystem/kali-armhf
 PRESERVED_PATH=$PATH
 export PATH=/usr/bin:/usr/sbin:/bin:/usr/local/bin:/usr/local/sbin:$PATH
 export TERM=linux
@@ -111,9 +111,9 @@ if [ -d "$mnt/sdcard" ]; then
     rmdir $mnt/sdcard
 fi
 
-if [ -d "$mnt/external_sd" ]; then
-    rmdir $mnt/external_sd
-fi
+#if [ -d "$mnt/external_sd" ]; then
+#    rmdir $mnt/external_sd
+#fi
 
 if [ $($busybox umount $mnt 2>&1 > /dev/null) ]; then
     echo " [-] Unable to umount the kali chroot image."

--- a/assets/scripts/killkali
+++ b/assets/scripts/killkali
@@ -52,15 +52,15 @@ kill_pids
 # unmount everything
 
 bklog "[!] Removing all Kali mounts .."
-$busybox umount $mnt/dev/shm && echo "unmounted shm"
-$busybox umount $mnt/dev/pts && echo "unmounted pts"
+[ -f $mnt/dev/shm ] && $busybox umount $mnt/dev/shm && echo "unmounted shm"
+[ -f $mnt/dev/pts ] && $busybox umount $mnt/dev/pts && echo "unmounted pts"
 $busybox umount $mnt/dev && echo "unmounted dev"
 $busybox umount $mnt/proc && echo "unmounted proc"
 $busybox umount $mnt/sys && echo "unmounted sys"
 $busybox umount $mnt/system && echo "unmounted system"
 $busybox umount $mnt/lib/modules && echo "unmounted modules"
 $busybox umount $mnt/sdcard && echo "unmounted $mnt$sdcard"
-$busybox umount $mnt/external_sd && echo "unmounted external_sd"
+[ -f $mnt/external_sd ] && $busybox umount $mnt/external_sd && echo "unmounted external_sd"
 
 if [ -d "$mnt/dev/shm" ]; then
     rmdir $mnt/dev/shm
@@ -111,9 +111,9 @@ if [ -d "$mnt/sdcard" ]; then
     rmdir $mnt/sdcard
 fi
 
-#if [ -d "$mnt/external_sd" ]; then
-#    rmdir $mnt/external_sd
-#fi
+if [ -d "$mnt/external_sd" ]; then
+    rmdir $mnt/external_sd
+fi
 
 if [ $($busybox umount $mnt 2>&1 > /dev/null) ]; then
     echo " [-] Unable to umount the kali chroot image."


### PR DESCRIPTION
* bootkali slightly improved
* killkali now works good, several mount issues suppressed.

* Should had a check for external_sd in future
   when you not have it, something with mounts gets weird

 *The same for /dev/shm, a check if it exists then unmount
  If not, why then try at all

* Added a "get-keychain" tool for pulling those apt-get issues, probably put a button in CustomCommads.


Forgot to add the get-keychain to the transfer/install script. will do.
